### PR TITLE
Configure npm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ The below screenshot was captured from a [demo webpage](docs/demo.html) after dr
 
 ## Usage
 
-Simply include the [highlight.js](https://github.com/highlightjs/highlight.js) library in your webpage, then load this module.
+Simply include the [highlight.js](https://github.com/highlightjs/highlight.js) library in your webpage, then add this module.
+
+### npm package
+
+This module is hosted on npmjs.org as [highlight.js-tsql](https://www.npmjs.com/package/highlight.js-tsql).
 
 ### Static website or simple usage
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The below screenshot was captured from a [demo webpage](docs/demo.html) after dr
 
 ## Usage
 
-Simply include the Highlight.js library in your webpage, then load this module.
+Simply include the [highlight.js](https://github.com/highlightjs/highlight.js) library in your webpage, then load this module.
 
 ### Static website or simple usage
 
@@ -16,10 +16,7 @@ Simply load this module after loading Highlight.js. You'll use the minified vers
 
 ```html
 <script type="text/javascript" src="/path/to/highlight.min.js"></script>
-<script
-  type="text/javascript"
-  src="/path/to/highlightjs-tsql/dist/tsql.min.js"
-></script>
+<script type="text/javascript" src="/path/to/highlightjs-tsql/dist/tsql.min.js"></script>
 <link rel="stylesheet" href="/path/to/highlightjs-tsql/dist/ssms.min.css" />
 <script type="text/javascript">
   hljs.highlightAll();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "highlight.js-tsql",
+  "description": "Syntax highlighting for T-SQL.",
+  "keywords": [
+    "highlight",
+    "syntax",
+    "T-SQL",
+    "sql"
+  ],
+  "homepage": "https://github.com/highlightjs/highlightjs-tsql",
+  "version": "1.1.1",
+  "author": "Greg Smulko",
+  "bugs": {
+    "url": "https://github.com/highlightjs/highlightjs-tsql/issues"
+  },
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/highlightjs/highlightjs-tsql"
+  },
+  "files": [
+    "dist/tsql.min.js",
+    "dist/ssms.min.css"
+  ]
+}


### PR DESCRIPTION
Configure npm support. Closes #9.

Published at: https://www.npmjs.com/package/highlight.js-tsql

